### PR TITLE
Fix cheerio function calls within addTemplate

### DIFF
--- a/lib/ng-sst2js.js
+++ b/lib/ng-sst2js.js
@@ -20,8 +20,8 @@ var parseTemplates = function parseTemplates(content, htmlPath, moduleName) {
     output,
     selector = 'script[type="text/ng-template"]',
     addTemplate = function addTemplate() {
-      var id = this.attr('id'),
-        content = escapeContent(this.html());
+      var id = $(this).attr('id'),
+        content = escapeContent($(this).html());
       puts.push(util.format('  $templateCache.put(\'%s\',\n    \'%s\');', id,
         content));
     };


### PR DESCRIPTION
The addTemplate tried to call functions on this that don't exist, causing the "TypeError: undefined is not a function" error to occur.

```
TypeError: undefined is not a function
    at Object.addTemplate (\node_modules\karma-ng-server-side-template2js-preprocessor\lib\ng-sst2js.js:25:21)
```

Link to examples how to use elements within each() iteration functions: https://api.jquery.com/each/
